### PR TITLE
refactor: branch develop -> main 변경

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on: # 조건(트리거)
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "main" ]
 
 jobs:
 


### PR DESCRIPTION
### ⛑️ 작업 내용 
develop 브랜치로 merge할때마다 배포되면 eureka나 load balancing을 이용하는 의미가 없어지는것 같아
develop 브랜치로 merge한것은 local에서 확인하고
main으로 바꿈으로 정말 배포만을 위한 git action설정함
